### PR TITLE
Buttons on home

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,6 +1,13 @@
 <td-layout #layout>
   <td-navigation-drawer flex sidenavTitle="MoRide">
     <mat-nav-list>
+      <a mat-list-item [routerLink]="['']" (click)="layout.close()" routerLinkActive="nav-active">
+        <mat-icon>home</mat-icon>
+        Home
+        </a>
+    </mat-nav-list>
+
+    <mat-nav-list>
       <a mat-list-item [routerLink]="['/rides']" (click)="layout.close()" routerLinkActive="nav-active">
         <mat-icon>directions_car</mat-icon>
         Rides

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -1,8 +1,26 @@
 <div layout-gt-sm="row">
   <div flex-gt-sm="80" flex-offset-gt-sm="10">
     <mat-card>
-      <mat-card-title id="hello-world">{{ this.text }}</mat-card-title>
-      <mat-card-subtitle>this is a card</mat-card-subtitle>
+      <mat-card-title id="hello-world">MoRide Home</mat-card-title>
+      <mat-card-subtitle>
+        Welcome to MoRide! You can look for and post rides for the Morris Community.
+      </mat-card-subtitle>
+      <div>
+        <button id="rideslistbutton" mat-raised-button
+                routerLink="/rides"
+                color="primary"
+                type="button">
+          <mat-icon>directions_car</mat-icon>
+          View Rides
+        </button>
+
+        <button mat-raised-button
+                routerLink="/addride"
+                type="button">
+          <mat-icon>add_circle_outline</mat-icon>
+          Add Rides
+        </button>
+      </div>
       <mat-divider></mat-divider>
       <mat-card-content>
         <div
@@ -13,7 +31,6 @@
           <mat-icon>exit_to_app</mat-icon>
           Sign Out
         </div>
-
       </mat-card-content>
     </mat-card>
   </div>


### PR DESCRIPTION
Adds a few ways to navigate around and makes the home page user friendly.

Home page no longer says stuff about the mongo lab:
"**MoRide Home**
Welcome to MoRide! You can look for and post rides for the Morris Community."

The home page below the new message has two buttons. One being a blue button to go to View Rides, and a white button to add a ride. 

Lastly, the hamburger menu navigation now has a link to the home page. 